### PR TITLE
feature-157

### DIFF
--- a/backend/alembic/versions/f1c7a0d9b2e4_add_user_auth_services.py
+++ b/backend/alembic/versions/f1c7a0d9b2e4_add_user_auth_services.py
@@ -1,0 +1,74 @@
+"""add user auth services
+
+Revision ID: f1c7a0d9b2e4
+Revises: 45904853ac45
+Create Date: 2026-05-25 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f1c7a0d9b2e4"
+down_revision: Union[str, Sequence[str], None] = "45904853ac45"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+    op.alter_column("users", "hashed_password", existing_type=sa.String(), nullable=True)
+
+    op.create_table(
+        "user_password_credentials",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("algorithm", sa.String(length=50), nullable=False),
+        sa.Column("password_hash", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "algorithm", name="uq_user_password_algorithm"),
+    )
+    op.create_table(
+        "user_ldap_identities",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("external_id", sa.String(length=255), nullable=False),
+        sa.Column("id_attribute", sa.String(length=100), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id"),
+        sa.UniqueConstraint("external_id", "id_attribute", name="uq_ldap_external_identity"),
+    )
+
+    op.execute(
+        """
+        INSERT INTO user_password_credentials (id, user_id, algorithm, password_hash, created_at)
+        SELECT gen_random_uuid(), id, 'bcrypt', hashed_password, NOW()
+        FROM users
+        WHERE hashed_password IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute(
+        """
+        UPDATE users
+        SET hashed_password = credentials.password_hash
+        FROM user_password_credentials AS credentials
+        WHERE credentials.user_id = users.id
+          AND credentials.algorithm = 'bcrypt'
+        """
+    )
+    op.drop_table("user_ldap_identities")
+    op.drop_table("user_password_credentials")
+    op.alter_column("users", "hashed_password", existing_type=sa.String(), nullable=False)

--- a/backend/main.py
+++ b/backend/main.py
@@ -148,13 +148,11 @@ async def lifespan(app: FastAPI):
         admin_user = db.query(User).filter(User.username == "admin").first()
 
         if not admin_user:
-            hashed_pwd = auth.get_password_hash("admin")
-
             new_admin = User(
                 username="admin",
-                hashed_password=hashed_pwd,
                 role=UserRole.ADMIN
             )
+            auth.set_password_credential(new_admin, "admin")
 
             db.add(new_admin)
             db.commit()
@@ -299,12 +297,10 @@ def register(user_data: UserRegister, db: Session = Depends(get_db)):
             detail='Пользователь с таким именем уже существует'
         )
 
-    hashed_pwd = auth.get_password_hash(user_data.password)
-
     new_user = User(
         username=user_data.username,
-        hashed_password=hashed_pwd
     )
+    auth.set_password_credential(new_user, user_data.password)
 
     db.add(new_user)
     db.commit()
@@ -317,7 +313,7 @@ def register(user_data: UserRegister, db: Session = Depends(get_db)):
 def login(user_data: UserLogin, response: Response, db: Session = Depends(get_db)):
     existing_user = db.query(User).filter(User.username == user_data.username).first()
 
-    if not existing_user or not auth.verify_password(user_data.password, existing_user.hashed_password):
+    if not existing_user or not auth.verify_user_password(existing_user, user_data.password):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail='Неверный логин или пароль'

--- a/backend/models.py
+++ b/backend/models.py
@@ -70,9 +70,70 @@ class User(Base):
         index=True,
         nullable=False
     )
-    hashed_password: Mapped[str] = mapped_column(String)
+    hashed_password: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     
     role: Mapped[UserRole] =  mapped_column(SQLAlchemyEnum(UserRole), default=UserRole.USER)
+
+    password_credentials: Mapped[List["UserPasswordCredential"]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    ldap_identity: Mapped[Optional["UserLdapIdentity"]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
+
+    @property
+    def auth_services(self) -> Dict[str, Any]:
+        services: Dict[str, Any] = {
+            "password": {
+                credential.algorithm: credential.password_hash
+                for credential in self.password_credentials
+            }
+        }
+
+        if self.ldap_identity:
+            services["ldap"] = {
+                "id": self.ldap_identity.external_id,
+                "idAttribute": self.ldap_identity.id_attribute,
+            }
+
+        return services
+
+
+class UserPasswordCredential(Base):
+    __tablename__ = "user_password_credentials"
+    __table_args__ = (
+        UniqueConstraint("user_id", "algorithm", name="uq_user_password_algorithm"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    algorithm: Mapped[str] = mapped_column(String(50), nullable=False)
+    password_hash: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.now)
+
+    user: Mapped["User"] = relationship(back_populates="password_credentials")
+
+
+class UserLdapIdentity(Base):
+    __tablename__ = "user_ldap_identities"
+    __table_args__ = (
+        UniqueConstraint("external_id", "id_attribute", name="uq_ldap_external_identity"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False
+    )
+    external_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    id_attribute: Mapped[str] = mapped_column(String(100), nullable=False, default="uid")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.now)
+
+    user: Mapped["User"] = relationship(back_populates="ldap_identity")
 
 
 class Group(Base):

--- a/backend/utils/auth.py
+++ b/backend/utils/auth.py
@@ -37,6 +37,40 @@ def get_password_hash(password):
     return pwd_context.hash(password)
 
 
+def set_password_credential(user: models.User, password: str, algorithm: str = "bcrypt"):
+    password_hash = get_password_hash(password)
+
+    for credential in user.password_credentials:
+        if credential.algorithm == algorithm:
+            credential.password_hash = password_hash
+            return credential
+
+    credential = models.UserPasswordCredential(
+        algorithm=algorithm,
+        password_hash=password_hash,
+    )
+    user.password_credentials.append(credential)
+    return credential
+
+
+def verify_user_password(user: models.User, plain_password: str) -> bool:
+    bcrypt_credential = next(
+        (
+            credential for credential in user.password_credentials
+            if credential.algorithm == "bcrypt"
+        ),
+        None,
+    )
+
+    if bcrypt_credential:
+        return verify_password(plain_password, bcrypt_credential.password_hash)
+
+    if user.hashed_password:
+        return verify_password(plain_password, user.hashed_password)
+
+    return False
+
+
 def create_access_token(data: dict):
     to_encode = data.copy()
     expire = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)


### PR DESCRIPTION
Название задач: Переделать модель авторизации пользователя под auth_services.
Описание изменений: модель авторизации пользователя вынесена в реляционные таблицы для password credentials и LDAP identity, добавлено свойство auth_services, регистрация и login используют password bcrypt credential, миграция переносит старые hashed_password в новую структуру.
Ссылка на issues: #157