### PR TITLE
feature-181

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
           --cov=utils
           --cov-report=term-missing
           --cov-report=xml
-          --cov-fail-under=45
+          --cov-fail-under=80
 
       - name: Upload backend test results
         if: always()

--- a/backend/tests/test_exporters_more.py
+++ b/backend/tests/test_exporters_more.py
@@ -1,0 +1,129 @@
+import io
+
+from openpyxl import load_workbook
+
+from utils.export_excel import ExcelExporter, MultiSurveyExporter, _excel_value, _question_label
+from utils.export_pdf import PDFExporter
+from utils.visualization_functions import Answer, Survey, SurveyVisualizer
+
+
+def _visualizer_with_all_question_types():
+    survey = Survey(
+        id="survey",
+        title="Export survey",
+        description="Description",
+        questions=[
+            {"id": "choice", "report_label": "Choice label", "title": "Choice", "type": "radio", "answers": ["A", "B", "C"]},
+            {"id": "number", "title": "Number", "type": "scale"},
+            {"id": "boolean", "title": "Boolean", "type": "boolean"},
+            {"id": "text", "title": "Text", "type": "text"},
+        ],
+    )
+    answers = [
+        Answer(
+            id="a1",
+            survey_id="survey",
+            group="3341",
+            answers=[
+                {"id_question": "choice", "value": "A"},
+                {"id_question": "number", "value": 5},
+                {"id_question": "boolean", "value": "true"},
+                {"id_question": "text", "value": "alpha beta"},
+            ],
+        ),
+        Answer(
+            id="a2",
+            survey_id="survey",
+            group="3342",
+            answers=[
+                {"id_question": "choice", "value": "B"},
+                {"id_question": "number", "value": 3},
+                {"id_question": "boolean", "value": "false"},
+                {"id_question": "text", "value": ""},
+            ],
+        ),
+    ]
+    return SurveyVisualizer([survey], answers)
+
+
+def test_excel_helpers_cover_labels_and_complex_values():
+    assert _question_label({"report_label": "Custom"}, 2) == "Custom"
+    assert _question_label({}, 2) == "Question 2"
+    assert _excel_value(None) == ""
+    assert _excel_value(["A", "B"]) == "['A', 'B']"
+
+
+def test_excel_exporter_writes_all_question_type_sheets():
+    visualizer = _visualizer_with_all_question_types()
+
+    data = ExcelExporter(visualizer).export_survey_to_excel("survey")
+    workbook = load_workbook(io.BytesIO(data), read_only=True)
+
+    assert workbook.sheetnames == ["General Information", "Raw Data", "Q1", "Q2", "Q3", "Q4"]
+    assert workbook["Raw Data"]["A1"].value == "Answer ID"
+    assert workbook["Q1"]["A1"].value == "Choice label: Choice"
+    assert workbook["Q1"]["A4"].value == "Response Distribution"
+    assert workbook["Q2"]["A4"].value == "Numeric Statistics"
+    assert workbook["Q3"]["A4"].value == "Boolean Statistics"
+    assert workbook["Q4"]["A4"].value == "Text Statistics"
+
+
+def test_excel_exporter_handles_missing_survey_and_empty_data():
+    visualizer = SurveyVisualizer([
+        Survey(id="empty", title="Empty", description="", questions=[])
+    ], [])
+
+    data = ExcelExporter(visualizer).export_survey_to_excel("empty")
+    workbook = load_workbook(io.BytesIO(data), read_only=True)
+
+    assert workbook["Raw Data"]["A1"].value == "No data available"
+
+    try:
+        ExcelExporter(visualizer).export_survey_to_excel("missing")
+    except ValueError as exc:
+        assert "missing" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for missing survey")
+
+
+def test_multi_survey_exporter_builds_table_of_contents():
+    visualizer = _visualizer_with_all_question_types()
+
+    data = MultiSurveyExporter(visualizer).export_all_surveys(filename=None)
+    workbook = load_workbook(io.BytesIO(data), read_only=True)
+
+    assert workbook.sheetnames[0] == "Table of Contents"
+    assert workbook["Table of Contents"]["A1"].value == "All Surveys Report"
+    assert workbook["Table of Contents"]["B7"].value == "Export survey"
+
+
+def test_pdf_exporter_covers_question_type_branches_without_charts():
+    visualizer = _visualizer_with_all_question_types()
+
+    data = PDFExporter(visualizer).export_survey_to_pdf("survey", include_charts=False)
+
+    assert data.startswith(b"%PDF")
+
+
+def test_pdf_exporter_covers_chart_branches():
+    visualizer = _visualizer_with_all_question_types()
+
+    data = PDFExporter(visualizer).export_survey_to_pdf("survey", include_charts=True)
+
+    assert data.startswith(b"%PDF")
+
+
+def test_pdf_exporter_handles_missing_survey_and_empty_question_values():
+    visualizer = SurveyVisualizer([
+        Survey(id="empty", title="Empty", description="", questions=[{"id": "q", "title": "Q", "type": "text"}])
+    ], [])
+    exporter = PDFExporter(visualizer)
+
+    assert exporter._create_question_analysis("empty", {"id": "q", "title": "Q", "type": "text"}, False, 1) == []
+
+    try:
+        exporter.export_survey_to_pdf("missing")
+    except ValueError as exc:
+        assert "missing" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for missing survey")

--- a/backend/tests/test_parser_units.py
+++ b/backend/tests/test_parser_units.py
@@ -1,0 +1,169 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pandas as pd
+import pytest
+from fastapi import HTTPException
+
+from models import Discipline, Group, GroupTeacherDiscipline, Survey, Teacher
+from utils import parser
+
+
+TEACHER = "Преподаватель"
+SUBJECT = "Дисциплина"
+GROUP = "Группа"
+
+
+def test_extract_sheet_id_accepts_google_sheet_url_and_rejects_invalid_url():
+    assert parser.extract_sheet_id("https://docs.google.com/spreadsheets/d/sheet_123-Abc/edit") == "sheet_123-Abc"
+
+    with pytest.raises(HTTPException) as exc:
+        parser.extract_sheet_id("https://example.com/not-a-sheet")
+
+    assert exc.value.status_code == 422
+
+
+def test_parse_groups_strips_notes_and_numeric_suffixes():
+    assert parser._parse_groups("3341 (PI), 3342.0, bad group, 3381") == [
+        "3341",
+        "3342",
+        "bad group",
+        "3381",
+    ]
+    assert parser._parse_groups(None) == []
+
+
+def test_header_detection_and_column_tag_names():
+    dataframe = pd.DataFrame([
+        ["noise", None, None],
+        [TEACHER, SUBJECT, GROUP],
+    ])
+
+    assert parser._detect_header_row(dataframe) == 1
+    assert parser._column_tag_name(TEACHER, "fallback") == "teacher"
+    assert parser._column_tag_name(GROUP, "fallback") == "group"
+    assert parser._column_tag_name(SUBJECT, "fallback") == "subject"
+    assert parser._column_tag_name("custom tag", "fallback") == "custom_tag"
+    assert parser._column_tag_name("", "fallback") == "fallback"
+
+
+def test_get_sheet_columns_handles_duplicate_tags_and_labels():
+    workbook = SimpleNamespace(
+        sheet_names=["First", "Second"],
+        parse=lambda sheet_name, header=None: pd.DataFrame([
+            [TEACHER, SUBJECT, GROUP, GROUP],
+            ["Teacher A", "Math", "3341", "3381"],
+        ]),
+    )
+
+    columns = parser._get_sheet_columns(workbook)
+
+    assert [column["value"] for column in columns] == [
+        "{{teacher}}",
+        "{{subject}}",
+        "{{group}}",
+        "{{group_2}}",
+        "{{teacher_2}}",
+        "{{subject_2}}",
+        "{{group_3}}",
+        "{{group_4}}",
+    ]
+    assert [column["sheet"] for column in columns] == ["First"] * 4 + ["Second"] * 4
+
+
+def test_fetch_records_combines_sheets_and_assigns_source_order(monkeypatch):
+    workbook = SimpleNamespace(
+        sheet_names=["First", "Second"],
+        parse=lambda sheet_name, header=None: pd.DataFrame([
+            [TEACHER, SUBJECT, GROUP],
+            [f"Teacher {sheet_name}", "Math", "3341"],
+        ]),
+    )
+    monkeypatch.setattr(parser, "download_workbook", lambda sheet_id: workbook)
+
+    records = parser._fetch_records("https://docs.google.com/spreadsheets/d/abc/edit")
+
+    assert [record["source_sheet"] for record in records] == ["First", "Second"]
+    assert [record["source_order"] for record in records] == [0, 1]
+    assert records[0]["teacher"] == "Teacher First"
+
+
+def test_get_sheet_groups_returns_empty_list_when_fetch_fails(monkeypatch):
+    def raise_http_error(url):
+        raise HTTPException(status_code=422, detail="broken")
+
+    monkeypatch.setattr(parser, "_fetch_records", raise_http_error)
+
+    assert parser.get_sheet_groups("broken-url") == []
+
+
+def test_get_sheet_tags_for_group_limits_tags_to_matching_sheet(monkeypatch):
+    workbook = SimpleNamespace(
+        sheet_names=["Allowed", "Denied"],
+        parse=lambda sheet_name, header=None: pd.DataFrame([
+            [TEACHER, SUBJECT, GROUP],
+            [f"Teacher {sheet_name}", "Math", "3341" if sheet_name == "Allowed" else "3381"],
+        ]),
+    )
+    monkeypatch.setattr(parser, "download_workbook", lambda sheet_id: workbook)
+
+    assert parser.get_sheet_tags_for_group("https://docs.google.com/spreadsheets/d/abc/edit", "3341") == [
+        "group",
+        "subject",
+        "teacher",
+    ]
+
+
+def test_populate_creates_and_updates_schedule_records(db_session):
+    survey_id = uuid4()
+    suffix = str(survey_id)[:8]
+    teacher_name = f"Populate Teacher {suffix}"
+    discipline_name = f"Populate Discipline {suffix}"
+    first_group = f"p{suffix[:4]}"
+    second_group = f"p{suffix[4:]}"
+    db_session.add(Survey(
+        id=survey_id,
+        title=f"Populate Survey {suffix}",
+        description="Description",
+        groups=[first_group, second_group],
+        questions=[],
+        is_active=True,
+    ))
+    db_session.flush()
+    records = [
+        {
+            "teacher": teacher_name,
+            "discipline": discipline_name,
+            "groups": [first_group, second_group],
+            "source_order": 4,
+        }
+    ]
+
+    stats = parser._populate(records, db_session, survey_id)
+
+    assert stats["groups"] >= 2
+    assert stats["teachers"] >= 1
+    assert stats["disciplines"] >= 1
+    assignments = (
+        db_session.query(GroupTeacherDiscipline)
+        .join(Group)
+        .join(Teacher)
+        .join(Discipline)
+        .filter(GroupTeacherDiscipline.survey_id == survey_id)
+        .filter(Teacher.name == teacher_name)
+        .filter(Discipline.name == discipline_name)
+        .all()
+    )
+    assert {assignment.group.name for assignment in assignments} == {first_group, second_group}
+    assert {assignment.source_order for assignment in assignments} == {4}
+
+    records[0]["source_order"] = 9
+    parser._populate(records, db_session, survey_id)
+
+    updated_orders = {
+        assignment.source_order
+        for assignment in db_session.query(GroupTeacherDiscipline)
+        .filter(GroupTeacherDiscipline.survey_id == survey_id)
+        .all()
+    }
+    assert updated_orders == {9}

--- a/backend/tests/test_report_factory_units.py
+++ b/backend/tests/test_report_factory_units.py
@@ -1,0 +1,157 @@
+from types import SimpleNamespace
+
+import pandas as pd
+
+from utils import report_factory as rf
+
+
+def test_tag_helpers_read_titles_answers_and_options():
+    question = {
+        "title": "Rate {{teacher_2}} and {{subject}}",
+        "answers": [{"value": "{{group}}"}, "plain"],
+        "options": [{"value": "{{ignored}}"}],
+    }
+
+    assert rf._get_base_tag("teacher_2") == "teacher"
+    assert rf._question_tags(question) == ["teacher_2", "subject", "group", "ignored"]
+    assert rf._uses_tag(question, "teacher")
+    assert rf._uses_tag(question, "subject")
+    assert not rf._uses_tag(question, "missing")
+
+
+def test_replace_tags_keeps_missing_values_as_templates():
+    value = "{{teacher}} teaches {{subject}} for {{group}}"
+
+    assert rf._replace_tags(value, {"teacher": "Teacher A", "subject": ""}) == (
+        "Teacher A teaches {{subject}} for {{group}}"
+    )
+
+
+def test_normalize_question_handles_choice_and_scale_shapes():
+    radio = rf._normalize_question(
+        {
+            "id": "q",
+            "title": "{{teacher}} rating",
+            "type": "radio",
+            "options": [{"value": "{{subject}}"}, "Other"],
+        },
+        {"teacher": "Teacher A", "subject": "Math"},
+        "generated-radio",
+    )
+    scale = rf._normalize_question(
+        {
+            "id": "scale",
+            "title": "Score",
+            "type": "scale",
+            "options": {"min": 1, "max": 5, "step": 1},
+        },
+        {},
+        "generated-scale",
+    )
+
+    assert radio["id"] == "generated-radio"
+    assert radio["title"] == "Teacher A rating"
+    assert radio["answers"] == ["Math", "Other"]
+    assert scale["min"] == 1
+    assert scale["max"] == 5
+    assert scale["step"] == 1
+
+
+def test_append_question_skips_unresolved_or_non_passing_questions():
+    result = []
+
+    rf._append_question(
+        result,
+        {"id": "q1", "title": "{{teacher}}", "type": "text"},
+        {"teacher": ""},
+        "q1",
+    )
+    rf._append_question(
+        result,
+        {"id": "q2", "title": "{{teacher}}", "type": "file"},
+        {"teacher": "Teacher A"},
+        "q2",
+    )
+    rf._append_question(
+        result,
+        {"id": "q3", "title": "{{teacher}}", "type": "text"},
+        {"teacher": "Teacher A"},
+        "q3",
+    )
+
+    assert [question["id"] for question in result] == ["q3"]
+
+
+def test_expand_blueprint_subject_first_groups_teachers_by_subject():
+    blueprint = {
+        "id": "bp",
+        "type": "blueprint",
+        "options": [
+            {"id": "subject", "title": "{{subject}}", "type": "text"},
+            {"id": "teacher", "title": "{{teacher}} on {{subject}}", "type": "radio", "answers": ["yes"]},
+        ],
+    }
+    pairs = [
+        {"teacher": "Teacher A", "subject": "Databases"},
+        {"teacher": "Teacher B", "subject": "Databases"},
+        {"teacher": "Teacher C", "subject": "Networks"},
+    ]
+
+    expanded = rf._expand_blueprint(blueprint, pairs, "3341")
+
+    assert [question["title"] for question in expanded] == [
+        "Databases",
+        "Teacher A on Databases",
+        "Teacher B on Databases",
+        "Networks",
+        "Teacher C on Networks",
+    ]
+    assert expanded[1]["id"] == "bp-Databases-Teacher A-teacher"
+
+
+def test_expand_blueprint_teacher_first_keeps_all_subjects_for_teacher():
+    blueprint = {
+        "id": "bp",
+        "type": "blueprint",
+        "options": [
+            {"id": "teacher", "title": "{{teacher}}", "type": "text"},
+            {"id": "subject", "title": "{{subject}}", "type": "text"},
+        ],
+    }
+    pairs = [
+        {"teacher": "Teacher A", "subject": "Lecture"},
+        {"teacher": "Teacher A", "subject": "Lab"},
+    ]
+
+    expanded = rf._expand_blueprint(blueprint, pairs, "3341")
+
+    assert [question["title"] for question in expanded] == [
+        "Teacher A",
+        "Lecture",
+        "Lab",
+    ]
+
+
+def test_build_report_visualizer_resolves_fallback_generated_ids():
+    survey = SimpleNamespace(
+        id="survey-1",
+        title="Survey",
+        description="Description",
+        questions=[
+            {"id": "template", "title": "Template question", "type": "text"}
+        ],
+        is_active=True,
+        created_at=None,
+    )
+    answer = SimpleNamespace(
+        id="answer-1",
+        survey_id="survey-1",
+        group="3341",
+        answers=[{"id_question": "bp-generated-template", "value": "ok"}],
+        created_at=None,
+    )
+
+    visualizer = rf.build_report_visualizer(survey, [answer])
+
+    assert visualizer.get_survey_data("survey-1").iloc[0]["q_template"] == "ok"
+    assert isinstance(visualizer.get_question_values("survey-1", "template"), pd.Series)

--- a/backend/tests/test_visualization_more.py
+++ b/backend/tests/test_visualization_more.py
@@ -1,0 +1,129 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from utils.visualization_functions import Answer, Survey, SurveyVisualizer
+
+
+def _close(fig):
+    plt.close(fig)
+
+
+def _visualizer():
+    survey = Survey(
+        id="s1",
+        title="Survey",
+        description="Description",
+        questions=[
+            {"id": "choice", "title": "Choice", "type": "radio", "answers": ["A", "B", "C"]},
+            {"id": "number", "title": "Number", "type": "scale"},
+            {"id": "boolean", "title": "Boolean", "type": "boolean"},
+            {"id": "text", "title": "Text", "type": "text"},
+        ],
+    )
+    answers = [
+        Answer(
+            id="a1",
+            survey_id="s1",
+            group="g1",
+            answers=[
+                {"id_question": "choice", "value": "A"},
+                {"id_question": "number", "value": 1},
+                {"id_question": "boolean", "value": "true"},
+                {"id_question": "text", "value": "alpha beta gamma"},
+            ],
+        ),
+        Answer(
+            id="a2",
+            survey_id="s1",
+            group="g2",
+            answers=[
+                {"id_question": "choice", "value": "B"},
+                {"id_question": "number", "value": 5},
+                {"id_question": "boolean", "value": "false"},
+                {"id_question": "text", "value": "alpha delta"},
+            ],
+        ),
+    ]
+    return SurveyVisualizer([survey], answers)
+
+
+def test_plot_choice_covers_both_horizontal_and_pie_branches():
+    values = pd.Series(["A", "A", "B"])
+    visualizer = _visualizer()
+
+    for chart_type, min_axes in [("both", 2), ("horizontal", 1), ("pie", 1)]:
+        fig = visualizer.plot_choice(values, "Choice", chart_type=chart_type, options=["A", "B", "C"])
+        assert isinstance(fig, plt.Figure)
+        assert len(fig.axes) >= min_axes
+        _close(fig)
+
+
+def test_plot_numeric_covers_all_chart_branches_and_empty_data():
+    values = pd.Series([1, 2, 3, 4])
+    visualizer = _visualizer()
+
+    for chart_type in ["all", "box", "violin", "ecdf", "summary"]:
+        fig = visualizer.plot_numeric(values, "Number", chart_type=chart_type, figsize=(7, 5))
+        assert isinstance(fig, plt.Figure)
+        _close(fig)
+
+    empty_fig = visualizer.plot_numeric(pd.Series(["bad", None]), "Number")
+    assert isinstance(empty_fig, plt.Figure)
+    _close(empty_fig)
+
+
+def test_plot_text_covers_summary_and_long_examples():
+    values = pd.Series(["x" * 90, "short", "another", "last"])
+    visualizer = _visualizer()
+
+    summary_fig = visualizer.plot_text(values, "Text", chart_type="summary")
+    list_fig = visualizer.plot_text(values, "Text", chart_type="list", max_examples=2)
+
+    assert isinstance(summary_fig, plt.Figure)
+    assert isinstance(list_fig, plt.Figure)
+    _close(summary_fig)
+    _close(list_fig)
+
+
+def test_plot_boolean_covers_both_and_pie_branches():
+    values = pd.Series(["true", "false", "maybe"])
+    visualizer = _visualizer()
+
+    for chart_type, min_axes in [("both", 2), ("pie", 1)]:
+        fig = visualizer.plot_boolean(values, "Boolean", chart_type=chart_type)
+        assert isinstance(fig, plt.Figure)
+        assert len(fig.axes) >= min_axes
+        _close(fig)
+
+
+def test_word_cloud_and_word_comparison_cover_empty_and_non_empty_paths():
+    visualizer = _visualizer()
+
+    empty_word_cloud = visualizer.plot_word_cloud(pd.Series(["a", ""]), "Text")
+    comparison = visualizer.plot_word_comparison(
+        pd.Series(["alpha beta", "alpha", "beta", "none"]),
+        "Text",
+        ["alpha"],
+        ["beta"],
+    )
+
+    assert isinstance(empty_word_cloud, plt.Figure)
+    assert isinstance(comparison, plt.Figure)
+    _close(empty_word_cloud)
+    _close(comparison)
+
+
+def test_plot_choice_by_group_handles_missing_column_and_empty_values():
+    visualizer = _visualizer()
+
+    missing_column = visualizer.plot_choice_by_group("s1", "missing", "Missing")
+    empty_values = visualizer.plot_choice_by_group("s1", "text", "Text with empty values")
+
+    assert isinstance(missing_column, plt.Figure)
+    assert isinstance(empty_values, plt.Figure)
+    _close(missing_column)
+    _close(empty_values)

--- a/backend/utils/export_excel.py
+++ b/backend/utils/export_excel.py
@@ -285,8 +285,8 @@ class MultiSurveyExporter:
             temp_exporter._create_info_sheet(temp_wb, survey)
             temp_exporter._create_raw_data_sheet(temp_wb, survey_id, survey)
 
-            for question in survey.questions:
-                temp_exporter._create_question_stats_sheet(temp_wb, survey_id, question)
+            for idx, question in enumerate(survey.questions, start=1):
+                temp_exporter._create_question_stats_sheet(temp_wb, survey_id, question, idx)
 
             for sheet_name in temp_wb.sheetnames:
                 source_sheet = temp_wb[sheet_name]


### PR DESCRIPTION
Название задач: Расширить автоматизацию тестирования и поднять backend coverage.
Описание изменений: добавлены unit-тесты для парсера Google Sheets, report factory, визуализации и экспорта PDF/Excel; исправлен multi-survey Excel export; порог покрытия backend в GitHub Actions поднят до 80%.
Ссылка на issues: #181