### PR TITLE
feature-182

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
           --cov=utils
           --cov-report=term-missing
           --cov-report=xml
-          --cov-fail-under=45
+          --cov-fail-under=80
 
       - name: Upload backend test results
         if: always()

--- a/backend/tests/test_exporters_more.py
+++ b/backend/tests/test_exporters_more.py
@@ -1,0 +1,129 @@
+import io
+
+from openpyxl import load_workbook
+
+from utils.export_excel import ExcelExporter, MultiSurveyExporter, _excel_value, _question_label
+from utils.export_pdf import PDFExporter
+from utils.visualization_functions import Answer, Survey, SurveyVisualizer
+
+
+def _visualizer_with_all_question_types():
+    survey = Survey(
+        id="survey",
+        title="Export survey",
+        description="Description",
+        questions=[
+            {"id": "choice", "report_label": "Choice label", "title": "Choice", "type": "radio", "answers": ["A", "B", "C"]},
+            {"id": "number", "title": "Number", "type": "scale"},
+            {"id": "boolean", "title": "Boolean", "type": "boolean"},
+            {"id": "text", "title": "Text", "type": "text"},
+        ],
+    )
+    answers = [
+        Answer(
+            id="a1",
+            survey_id="survey",
+            group="3341",
+            answers=[
+                {"id_question": "choice", "value": "A"},
+                {"id_question": "number", "value": 5},
+                {"id_question": "boolean", "value": "true"},
+                {"id_question": "text", "value": "alpha beta"},
+            ],
+        ),
+        Answer(
+            id="a2",
+            survey_id="survey",
+            group="3342",
+            answers=[
+                {"id_question": "choice", "value": "B"},
+                {"id_question": "number", "value": 3},
+                {"id_question": "boolean", "value": "false"},
+                {"id_question": "text", "value": ""},
+            ],
+        ),
+    ]
+    return SurveyVisualizer([survey], answers)
+
+
+def test_excel_helpers_cover_labels_and_complex_values():
+    assert _question_label({"report_label": "Custom"}, 2) == "Custom"
+    assert _question_label({}, 2) == "Question 2"
+    assert _excel_value(None) == ""
+    assert _excel_value(["A", "B"]) == "['A', 'B']"
+
+
+def test_excel_exporter_writes_all_question_type_sheets():
+    visualizer = _visualizer_with_all_question_types()
+
+    data = ExcelExporter(visualizer).export_survey_to_excel("survey")
+    workbook = load_workbook(io.BytesIO(data), read_only=True)
+
+    assert workbook.sheetnames == ["General Information", "Raw Data", "Q1", "Q2", "Q3", "Q4"]
+    assert workbook["Raw Data"]["A1"].value == "Answer ID"
+    assert workbook["Q1"]["A1"].value == "Choice label: Choice"
+    assert workbook["Q1"]["A4"].value == "Response Distribution"
+    assert workbook["Q2"]["A4"].value == "Numeric Statistics"
+    assert workbook["Q3"]["A4"].value == "Boolean Statistics"
+    assert workbook["Q4"]["A4"].value == "Text Statistics"
+
+
+def test_excel_exporter_handles_missing_survey_and_empty_data():
+    visualizer = SurveyVisualizer([
+        Survey(id="empty", title="Empty", description="", questions=[])
+    ], [])
+
+    data = ExcelExporter(visualizer).export_survey_to_excel("empty")
+    workbook = load_workbook(io.BytesIO(data), read_only=True)
+
+    assert workbook["Raw Data"]["A1"].value == "No data available"
+
+    try:
+        ExcelExporter(visualizer).export_survey_to_excel("missing")
+    except ValueError as exc:
+        assert "missing" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for missing survey")
+
+
+def test_multi_survey_exporter_builds_table_of_contents():
+    visualizer = _visualizer_with_all_question_types()
+
+    data = MultiSurveyExporter(visualizer).export_all_surveys(filename=None)
+    workbook = load_workbook(io.BytesIO(data), read_only=True)
+
+    assert workbook.sheetnames[0] == "Table of Contents"
+    assert workbook["Table of Contents"]["A1"].value == "All Surveys Report"
+    assert workbook["Table of Contents"]["B7"].value == "Export survey"
+
+
+def test_pdf_exporter_covers_question_type_branches_without_charts():
+    visualizer = _visualizer_with_all_question_types()
+
+    data = PDFExporter(visualizer).export_survey_to_pdf("survey", include_charts=False)
+
+    assert data.startswith(b"%PDF")
+
+
+def test_pdf_exporter_covers_chart_branches():
+    visualizer = _visualizer_with_all_question_types()
+
+    data = PDFExporter(visualizer).export_survey_to_pdf("survey", include_charts=True)
+
+    assert data.startswith(b"%PDF")
+
+
+def test_pdf_exporter_handles_missing_survey_and_empty_question_values():
+    visualizer = SurveyVisualizer([
+        Survey(id="empty", title="Empty", description="", questions=[{"id": "q", "title": "Q", "type": "text"}])
+    ], [])
+    exporter = PDFExporter(visualizer)
+
+    assert exporter._create_question_analysis("empty", {"id": "q", "title": "Q", "type": "text"}, False, 1) == []
+
+    try:
+        exporter.export_survey_to_pdf("missing")
+    except ValueError as exc:
+        assert "missing" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for missing survey")

--- a/backend/tests/test_parser_units.py
+++ b/backend/tests/test_parser_units.py
@@ -1,0 +1,169 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pandas as pd
+import pytest
+from fastapi import HTTPException
+
+from models import Discipline, Group, GroupTeacherDiscipline, Survey, Teacher
+from utils import parser
+
+
+TEACHER = "Преподаватель"
+SUBJECT = "Дисциплина"
+GROUP = "Группа"
+
+
+def test_extract_sheet_id_accepts_google_sheet_url_and_rejects_invalid_url():
+    assert parser.extract_sheet_id("https://docs.google.com/spreadsheets/d/sheet_123-Abc/edit") == "sheet_123-Abc"
+
+    with pytest.raises(HTTPException) as exc:
+        parser.extract_sheet_id("https://example.com/not-a-sheet")
+
+    assert exc.value.status_code == 422
+
+
+def test_parse_groups_strips_notes_and_numeric_suffixes():
+    assert parser._parse_groups("3341 (PI), 3342.0, bad group, 3381") == [
+        "3341",
+        "3342",
+        "bad group",
+        "3381",
+    ]
+    assert parser._parse_groups(None) == []
+
+
+def test_header_detection_and_column_tag_names():
+    dataframe = pd.DataFrame([
+        ["noise", None, None],
+        [TEACHER, SUBJECT, GROUP],
+    ])
+
+    assert parser._detect_header_row(dataframe) == 1
+    assert parser._column_tag_name(TEACHER, "fallback") == "teacher"
+    assert parser._column_tag_name(GROUP, "fallback") == "group"
+    assert parser._column_tag_name(SUBJECT, "fallback") == "subject"
+    assert parser._column_tag_name("custom tag", "fallback") == "custom_tag"
+    assert parser._column_tag_name("", "fallback") == "fallback"
+
+
+def test_get_sheet_columns_handles_duplicate_tags_and_labels():
+    workbook = SimpleNamespace(
+        sheet_names=["First", "Second"],
+        parse=lambda sheet_name, header=None: pd.DataFrame([
+            [TEACHER, SUBJECT, GROUP, GROUP],
+            ["Teacher A", "Math", "3341", "3381"],
+        ]),
+    )
+
+    columns = parser._get_sheet_columns(workbook)
+
+    assert [column["value"] for column in columns] == [
+        "{{teacher}}",
+        "{{subject}}",
+        "{{group}}",
+        "{{group_2}}",
+        "{{teacher_2}}",
+        "{{subject_2}}",
+        "{{group_3}}",
+        "{{group_4}}",
+    ]
+    assert [column["sheet"] for column in columns] == ["First"] * 4 + ["Second"] * 4
+
+
+def test_fetch_records_combines_sheets_and_assigns_source_order(monkeypatch):
+    workbook = SimpleNamespace(
+        sheet_names=["First", "Second"],
+        parse=lambda sheet_name, header=None: pd.DataFrame([
+            [TEACHER, SUBJECT, GROUP],
+            [f"Teacher {sheet_name}", "Math", "3341"],
+        ]),
+    )
+    monkeypatch.setattr(parser, "download_workbook", lambda sheet_id: workbook)
+
+    records = parser._fetch_records("https://docs.google.com/spreadsheets/d/abc/edit")
+
+    assert [record["source_sheet"] for record in records] == ["First", "Second"]
+    assert [record["source_order"] for record in records] == [0, 1]
+    assert records[0]["teacher"] == "Teacher First"
+
+
+def test_get_sheet_groups_returns_empty_list_when_fetch_fails(monkeypatch):
+    def raise_http_error(url):
+        raise HTTPException(status_code=422, detail="broken")
+
+    monkeypatch.setattr(parser, "_fetch_records", raise_http_error)
+
+    assert parser.get_sheet_groups("broken-url") == []
+
+
+def test_get_sheet_tags_for_group_limits_tags_to_matching_sheet(monkeypatch):
+    workbook = SimpleNamespace(
+        sheet_names=["Allowed", "Denied"],
+        parse=lambda sheet_name, header=None: pd.DataFrame([
+            [TEACHER, SUBJECT, GROUP],
+            [f"Teacher {sheet_name}", "Math", "3341" if sheet_name == "Allowed" else "3381"],
+        ]),
+    )
+    monkeypatch.setattr(parser, "download_workbook", lambda sheet_id: workbook)
+
+    assert parser.get_sheet_tags_for_group("https://docs.google.com/spreadsheets/d/abc/edit", "3341") == [
+        "group",
+        "subject",
+        "teacher",
+    ]
+
+
+def test_populate_creates_and_updates_schedule_records(db_session):
+    survey_id = uuid4()
+    suffix = str(survey_id)[:8]
+    teacher_name = f"Populate Teacher {suffix}"
+    discipline_name = f"Populate Discipline {suffix}"
+    first_group = f"p{suffix[:4]}"
+    second_group = f"p{suffix[4:]}"
+    db_session.add(Survey(
+        id=survey_id,
+        title=f"Populate Survey {suffix}",
+        description="Description",
+        groups=[first_group, second_group],
+        questions=[],
+        is_active=True,
+    ))
+    db_session.flush()
+    records = [
+        {
+            "teacher": teacher_name,
+            "discipline": discipline_name,
+            "groups": [first_group, second_group],
+            "source_order": 4,
+        }
+    ]
+
+    stats = parser._populate(records, db_session, survey_id)
+
+    assert stats["groups"] >= 2
+    assert stats["teachers"] >= 1
+    assert stats["disciplines"] >= 1
+    assignments = (
+        db_session.query(GroupTeacherDiscipline)
+        .join(Group)
+        .join(Teacher)
+        .join(Discipline)
+        .filter(GroupTeacherDiscipline.survey_id == survey_id)
+        .filter(Teacher.name == teacher_name)
+        .filter(Discipline.name == discipline_name)
+        .all()
+    )
+    assert {assignment.group.name for assignment in assignments} == {first_group, second_group}
+    assert {assignment.source_order for assignment in assignments} == {4}
+
+    records[0]["source_order"] = 9
+    parser._populate(records, db_session, survey_id)
+
+    updated_orders = {
+        assignment.source_order
+        for assignment in db_session.query(GroupTeacherDiscipline)
+        .filter(GroupTeacherDiscipline.survey_id == survey_id)
+        .all()
+    }
+    assert updated_orders == {9}

--- a/backend/tests/test_report_factory_units.py
+++ b/backend/tests/test_report_factory_units.py
@@ -1,0 +1,157 @@
+from types import SimpleNamespace
+
+import pandas as pd
+
+from utils import report_factory as rf
+
+
+def test_tag_helpers_read_titles_answers_and_options():
+    question = {
+        "title": "Rate {{teacher_2}} and {{subject}}",
+        "answers": [{"value": "{{group}}"}, "plain"],
+        "options": [{"value": "{{ignored}}"}],
+    }
+
+    assert rf._get_base_tag("teacher_2") == "teacher"
+    assert rf._question_tags(question) == ["teacher_2", "subject", "group", "ignored"]
+    assert rf._uses_tag(question, "teacher")
+    assert rf._uses_tag(question, "subject")
+    assert not rf._uses_tag(question, "missing")
+
+
+def test_replace_tags_keeps_missing_values_as_templates():
+    value = "{{teacher}} teaches {{subject}} for {{group}}"
+
+    assert rf._replace_tags(value, {"teacher": "Teacher A", "subject": ""}) == (
+        "Teacher A teaches {{subject}} for {{group}}"
+    )
+
+
+def test_normalize_question_handles_choice_and_scale_shapes():
+    radio = rf._normalize_question(
+        {
+            "id": "q",
+            "title": "{{teacher}} rating",
+            "type": "radio",
+            "options": [{"value": "{{subject}}"}, "Other"],
+        },
+        {"teacher": "Teacher A", "subject": "Math"},
+        "generated-radio",
+    )
+    scale = rf._normalize_question(
+        {
+            "id": "scale",
+            "title": "Score",
+            "type": "scale",
+            "options": {"min": 1, "max": 5, "step": 1},
+        },
+        {},
+        "generated-scale",
+    )
+
+    assert radio["id"] == "generated-radio"
+    assert radio["title"] == "Teacher A rating"
+    assert radio["answers"] == ["Math", "Other"]
+    assert scale["min"] == 1
+    assert scale["max"] == 5
+    assert scale["step"] == 1
+
+
+def test_append_question_skips_unresolved_or_non_passing_questions():
+    result = []
+
+    rf._append_question(
+        result,
+        {"id": "q1", "title": "{{teacher}}", "type": "text"},
+        {"teacher": ""},
+        "q1",
+    )
+    rf._append_question(
+        result,
+        {"id": "q2", "title": "{{teacher}}", "type": "file"},
+        {"teacher": "Teacher A"},
+        "q2",
+    )
+    rf._append_question(
+        result,
+        {"id": "q3", "title": "{{teacher}}", "type": "text"},
+        {"teacher": "Teacher A"},
+        "q3",
+    )
+
+    assert [question["id"] for question in result] == ["q3"]
+
+
+def test_expand_blueprint_subject_first_groups_teachers_by_subject():
+    blueprint = {
+        "id": "bp",
+        "type": "blueprint",
+        "options": [
+            {"id": "subject", "title": "{{subject}}", "type": "text"},
+            {"id": "teacher", "title": "{{teacher}} on {{subject}}", "type": "radio", "answers": ["yes"]},
+        ],
+    }
+    pairs = [
+        {"teacher": "Teacher A", "subject": "Databases"},
+        {"teacher": "Teacher B", "subject": "Databases"},
+        {"teacher": "Teacher C", "subject": "Networks"},
+    ]
+
+    expanded = rf._expand_blueprint(blueprint, pairs, "3341")
+
+    assert [question["title"] for question in expanded] == [
+        "Databases",
+        "Teacher A on Databases",
+        "Teacher B on Databases",
+        "Networks",
+        "Teacher C on Networks",
+    ]
+    assert expanded[1]["id"] == "bp-Databases-Teacher A-teacher"
+
+
+def test_expand_blueprint_teacher_first_keeps_all_subjects_for_teacher():
+    blueprint = {
+        "id": "bp",
+        "type": "blueprint",
+        "options": [
+            {"id": "teacher", "title": "{{teacher}}", "type": "text"},
+            {"id": "subject", "title": "{{subject}}", "type": "text"},
+        ],
+    }
+    pairs = [
+        {"teacher": "Teacher A", "subject": "Lecture"},
+        {"teacher": "Teacher A", "subject": "Lab"},
+    ]
+
+    expanded = rf._expand_blueprint(blueprint, pairs, "3341")
+
+    assert [question["title"] for question in expanded] == [
+        "Teacher A",
+        "Lecture",
+        "Lab",
+    ]
+
+
+def test_build_report_visualizer_resolves_fallback_generated_ids():
+    survey = SimpleNamespace(
+        id="survey-1",
+        title="Survey",
+        description="Description",
+        questions=[
+            {"id": "template", "title": "Template question", "type": "text"}
+        ],
+        is_active=True,
+        created_at=None,
+    )
+    answer = SimpleNamespace(
+        id="answer-1",
+        survey_id="survey-1",
+        group="3341",
+        answers=[{"id_question": "bp-generated-template", "value": "ok"}],
+        created_at=None,
+    )
+
+    visualizer = rf.build_report_visualizer(survey, [answer])
+
+    assert visualizer.get_survey_data("survey-1").iloc[0]["q_template"] == "ok"
+    assert isinstance(visualizer.get_question_values("survey-1", "template"), pd.Series)

--- a/backend/tests/test_reporting_exports.py
+++ b/backend/tests/test_reporting_exports.py
@@ -6,6 +6,7 @@ from models import Answer, Discipline, Group, GroupTeacherDiscipline, Survey, Te
 from utils.export_excel import ExcelExporter
 from utils.export_pdf import PDFExporter
 from utils.report_factory import build_report_visualizer
+from utils.visualization_functions import get_question_groups
 
 
 def _create_blueprint_survey(db_session, group_name):
@@ -83,6 +84,17 @@ def test_report_factory_expands_blueprints_for_answer_group(db_session):
         "Databases (labs) quality",
         "Teacher A teaches Databases (labs)",
     ]
+    groups = [
+        (question.get("report_group_label"), question["title"])
+        for question in report_survey.questions
+        if question.get("report_group_label")
+    ]
+    assert groups == [
+        ("Databases (lectures)", "Databases (lectures) quality"),
+        ("Databases (lectures)", "Teacher A teaches Databases (lectures)"),
+        ("Databases (labs)", "Databases (labs) quality"),
+        ("Databases (labs)", "Teacher A teaches Databases (labs)"),
+    ]
     data = visualizer.get_survey_data(survey_id).iloc[0]
     assert data["q_bp-Databases (lectures)-subject"] == "lecture subject answer"
     assert data["q_bp-Databases (labs)-Teacher A-teacher"] == "lab teacher answer"
@@ -105,8 +117,47 @@ def test_excel_and_pdf_exports_use_human_question_labels(db_session):
     workbook = load_workbook(io.BytesIO(excel_bytes), read_only=True)
 
     assert "Q2" in workbook.sheetnames
-    assert workbook["Q2"]["A1"].value == "Question 2: Databases (lectures) quality"
+    assert workbook["Q2"]["A1"].value == "Question 2: Databases (lectures)"
+    assert workbook["Q2"]["A2"].value == "Blueprint question group"
+    assert workbook["Q2"]["A4"].value == "Subquestion 1: Databases (lectures) quality"
     assert str(survey.id) not in workbook["Q2"]["A1"].value
 
     pdf_bytes = PDFExporter(visualizer).export_survey_to_pdf(survey_id, include_charts=False)
     assert pdf_bytes.startswith(b"%PDF")
+
+
+def test_pdf_blueprint_group_uses_subquestion_labels_and_charts(db_session):
+    group_name = "p3341"
+    survey = _create_blueprint_survey(db_session, group_name)
+    answer = Answer(
+        survey_id=survey.id,
+        group=group_name,
+        answers=[
+            {"id_question": "bp-Databases (lectures)-subject", "value": "useful clear material"},
+            {"id_question": "bp-Databases (lectures)-Teacher A-teacher", "value": "yes"},
+        ],
+    )
+    db_session.add(answer)
+    db_session.flush()
+
+    visualizer = build_report_visualizer(survey, [answer], db_session)
+    survey_id = str(survey.id)
+    groups = get_question_groups(visualizer.surveys[survey_id].questions)
+    blueprint_group = next(item for item in groups if item["type"] == "group")
+
+    story = PDFExporter(visualizer)._create_question_group_analysis(
+        survey_id,
+        blueprint_group,
+        include_charts=True,
+        index=2,
+    )
+    paragraph_text = "\n".join(
+        item.getPlainText()
+        for item in story
+        if hasattr(item, "getPlainText")
+    )
+
+    assert "Question 2: Databases (lectures)" in paragraph_text
+    assert "Subquestion 1: Databases (lectures) quality" in paragraph_text
+    assert "Subquestion 2: Teacher A teaches Databases (lectures)" in paragraph_text
+    assert any(item.__class__.__name__ == "Image" for item in story)

--- a/backend/tests/test_visualization_more.py
+++ b/backend/tests/test_visualization_more.py
@@ -1,0 +1,129 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from utils.visualization_functions import Answer, Survey, SurveyVisualizer
+
+
+def _close(fig):
+    plt.close(fig)
+
+
+def _visualizer():
+    survey = Survey(
+        id="s1",
+        title="Survey",
+        description="Description",
+        questions=[
+            {"id": "choice", "title": "Choice", "type": "radio", "answers": ["A", "B", "C"]},
+            {"id": "number", "title": "Number", "type": "scale"},
+            {"id": "boolean", "title": "Boolean", "type": "boolean"},
+            {"id": "text", "title": "Text", "type": "text"},
+        ],
+    )
+    answers = [
+        Answer(
+            id="a1",
+            survey_id="s1",
+            group="g1",
+            answers=[
+                {"id_question": "choice", "value": "A"},
+                {"id_question": "number", "value": 1},
+                {"id_question": "boolean", "value": "true"},
+                {"id_question": "text", "value": "alpha beta gamma"},
+            ],
+        ),
+        Answer(
+            id="a2",
+            survey_id="s1",
+            group="g2",
+            answers=[
+                {"id_question": "choice", "value": "B"},
+                {"id_question": "number", "value": 5},
+                {"id_question": "boolean", "value": "false"},
+                {"id_question": "text", "value": "alpha delta"},
+            ],
+        ),
+    ]
+    return SurveyVisualizer([survey], answers)
+
+
+def test_plot_choice_covers_both_horizontal_and_pie_branches():
+    values = pd.Series(["A", "A", "B"])
+    visualizer = _visualizer()
+
+    for chart_type, min_axes in [("both", 2), ("horizontal", 1), ("pie", 1)]:
+        fig = visualizer.plot_choice(values, "Choice", chart_type=chart_type, options=["A", "B", "C"])
+        assert isinstance(fig, plt.Figure)
+        assert len(fig.axes) >= min_axes
+        _close(fig)
+
+
+def test_plot_numeric_covers_all_chart_branches_and_empty_data():
+    values = pd.Series([1, 2, 3, 4])
+    visualizer = _visualizer()
+
+    for chart_type in ["all", "box", "violin", "ecdf", "summary"]:
+        fig = visualizer.plot_numeric(values, "Number", chart_type=chart_type, figsize=(7, 5))
+        assert isinstance(fig, plt.Figure)
+        _close(fig)
+
+    empty_fig = visualizer.plot_numeric(pd.Series(["bad", None]), "Number")
+    assert isinstance(empty_fig, plt.Figure)
+    _close(empty_fig)
+
+
+def test_plot_text_covers_summary_and_long_examples():
+    values = pd.Series(["x" * 90, "short", "another", "last"])
+    visualizer = _visualizer()
+
+    summary_fig = visualizer.plot_text(values, "Text", chart_type="summary")
+    list_fig = visualizer.plot_text(values, "Text", chart_type="list", max_examples=2)
+
+    assert isinstance(summary_fig, plt.Figure)
+    assert isinstance(list_fig, plt.Figure)
+    _close(summary_fig)
+    _close(list_fig)
+
+
+def test_plot_boolean_covers_both_and_pie_branches():
+    values = pd.Series(["true", "false", "maybe"])
+    visualizer = _visualizer()
+
+    for chart_type, min_axes in [("both", 2), ("pie", 1)]:
+        fig = visualizer.plot_boolean(values, "Boolean", chart_type=chart_type)
+        assert isinstance(fig, plt.Figure)
+        assert len(fig.axes) >= min_axes
+        _close(fig)
+
+
+def test_word_cloud_and_word_comparison_cover_empty_and_non_empty_paths():
+    visualizer = _visualizer()
+
+    empty_word_cloud = visualizer.plot_word_cloud(pd.Series(["a", ""]), "Text")
+    comparison = visualizer.plot_word_comparison(
+        pd.Series(["alpha beta", "alpha", "beta", "none"]),
+        "Text",
+        ["alpha"],
+        ["beta"],
+    )
+
+    assert isinstance(empty_word_cloud, plt.Figure)
+    assert isinstance(comparison, plt.Figure)
+    _close(empty_word_cloud)
+    _close(comparison)
+
+
+def test_plot_choice_by_group_handles_missing_column_and_empty_values():
+    visualizer = _visualizer()
+
+    missing_column = visualizer.plot_choice_by_group("s1", "missing", "Missing")
+    empty_values = visualizer.plot_choice_by_group("s1", "text", "Text with empty values")
+
+    assert isinstance(missing_column, plt.Figure)
+    assert isinstance(empty_values, plt.Figure)
+    _close(missing_column)
+    _close(empty_values)

--- a/backend/utils/export_excel.py
+++ b/backend/utils/export_excel.py
@@ -6,7 +6,15 @@ from openpyxl.styles import Font, PatternFill, Alignment, Border, Side
 from openpyxl.chart import BarChart, PieChart, Reference
 import io
 
-from utils.visualization_functions import Survey, SurveyVisualizer, normalize_question_type, get_question_id, get_question_text, get_question_options
+from utils.visualization_functions import (
+    Survey,
+    SurveyVisualizer,
+    normalize_question_type,
+    get_question_id,
+    get_question_text,
+    get_question_options,
+    get_question_groups,
+)
 
 
 def _question_label(question: Dict, index: int) -> str:
@@ -36,8 +44,11 @@ class ExcelExporter:
         self._create_info_sheet(wb, survey)
         self._create_raw_data_sheet(wb, survey_id, survey)
 
-        for idx, question in enumerate(survey.questions, start=1):
-            self._create_question_stats_sheet(wb, survey_id, question, idx)
+        for idx, item in enumerate(get_question_groups(survey.questions), start=1):
+            if item["type"] == "group":
+                self._create_question_group_stats_sheet(wb, survey_id, item, idx)
+            else:
+                self._create_question_stats_sheet(wb, survey_id, item["question"], idx)
 
         if filename:
             wb.save(filename)
@@ -128,24 +139,49 @@ class ExcelExporter:
             ws.column_dimensions[col_letter].width = max_length + 2
 
     def _create_question_stats_sheet(self, wb: Workbook, survey_id: int, question: Dict, index: int):
-        question_id = get_question_id(question)
-        question_text = get_question_text(question)
-        question_type = normalize_question_type(question.get('type', 'text'))
-        question_label = _question_label(question, index)
+        sheet_name = f"Q{index}"
+        ws = wb.create_sheet(sheet_name)
+        self._write_question_stats(ws, survey_id, question, index, 1)
 
+    def _create_question_group_stats_sheet(self, wb: Workbook, survey_id: int, group: Dict, index: int):
         sheet_name = f"Q{index}"
         ws = wb.create_sheet(sheet_name)
 
-        ws['A1'] = f"{question_label}: {question_text}"
+        ws['A1'] = f"Question {index}: {group['label']}"
         ws['A1'].font = Font(size=12, bold=True)
         ws.merge_cells('A1:F1')
-
-        ws['A2'] = f"Type: {question_type}"
+        ws['A2'] = "Blueprint question group"
         ws.merge_cells('A2:F2')
+
+        row = 4
+        for sub_index, question in enumerate(group["questions"], start=1):
+            row = self._write_question_stats(ws, survey_id, question, sub_index, row, prefix="Subquestion")
+            row += 2
+
+    def _write_question_stats(
+        self,
+        ws,
+        survey_id: int,
+        question: Dict,
+        index: int,
+        start_row: int,
+        prefix: str = "Question",
+    ) -> int:
+        question_id = get_question_id(question)
+        question_text = get_question_text(question)
+        question_type = normalize_question_type(question.get('type', 'text'))
+        question_label = question.get("report_label") or f"{prefix} {index}"
+
+        ws[f'A{start_row}'] = f"{question_label}: {question_text}"
+        ws[f'A{start_row}'].font = Font(size=12, bold=True)
+        ws.merge_cells(start_row=start_row, start_column=1, end_row=start_row, end_column=6)
+
+        ws[f'A{start_row + 1}'] = f"Type: {question_type}"
+        ws.merge_cells(start_row=start_row + 1, start_column=1, end_row=start_row + 1, end_column=6)
 
         values = self.visualizer.get_question_values(survey_id, question_id)
 
-        row = 4
+        row = start_row + 3
 
         if question_type == 'choice':
             stats = self.visualizer.stats.choice_stats(values, get_question_options(question))
@@ -262,6 +298,7 @@ class ExcelExporter:
         ws.column_dimensions['A'].width = 30
         ws.column_dimensions['B'].width = 15
         ws.column_dimensions['C'].width = 15
+        return row
 
 
 class MultiSurveyExporter:
@@ -285,8 +322,11 @@ class MultiSurveyExporter:
             temp_exporter._create_info_sheet(temp_wb, survey)
             temp_exporter._create_raw_data_sheet(temp_wb, survey_id, survey)
 
-            for idx, question in enumerate(survey.questions, start=1):
-                temp_exporter._create_question_stats_sheet(temp_wb, survey_id, question, idx)
+            for idx, item in enumerate(get_question_groups(survey.questions), start=1):
+                if item["type"] == "group":
+                    temp_exporter._create_question_group_stats_sheet(temp_wb, survey_id, item, idx)
+                else:
+                    temp_exporter._create_question_stats_sheet(temp_wb, survey_id, item["question"], idx)
 
             for sheet_name in temp_wb.sheetnames:
                 source_sheet = temp_wb[sheet_name]

--- a/backend/utils/export_excel.py
+++ b/backend/utils/export_excel.py
@@ -285,8 +285,8 @@ class MultiSurveyExporter:
             temp_exporter._create_info_sheet(temp_wb, survey)
             temp_exporter._create_raw_data_sheet(temp_wb, survey_id, survey)
 
-            for question in survey.questions:
-                temp_exporter._create_question_stats_sheet(temp_wb, survey_id, question)
+            for idx, question in enumerate(survey.questions, start=1):
+                temp_exporter._create_question_stats_sheet(temp_wb, survey_id, question, idx)
 
             for sheet_name in temp_wb.sheetnames:
                 source_sheet = temp_wb[sheet_name]

--- a/backend/utils/export_pdf.py
+++ b/backend/utils/export_pdf.py
@@ -16,7 +16,14 @@ from reportlab.pdfbase.ttfonts import TTFont
 import matplotlib.pyplot as plt
 import pandas as pd
 
-from utils.visualization_functions import SurveyVisualizer, normalize_question_type, get_question_id, get_question_text, get_question_options
+from utils.visualization_functions import (
+    SurveyVisualizer,
+    normalize_question_type,
+    get_question_id,
+    get_question_text,
+    get_question_options,
+    get_question_groups,
+)
 
 
 FONT_REGULAR = "Helvetica"
@@ -128,8 +135,11 @@ class PDFExporter:
         story.extend(self._create_survey_summary(survey_id, survey))
         story.append(PageBreak())
 
-        for idx, question in enumerate(survey.questions, start=1):
-            question_content = self._create_question_analysis(survey_id, question, include_charts, idx)
+        for idx, item in enumerate(get_question_groups(survey.questions), start=1):
+            if item["type"] == "group":
+                question_content = self._create_question_group_analysis(survey_id, item, include_charts, idx)
+            else:
+                question_content = self._create_question_analysis(survey_id, item["question"], include_charts, idx)
             if question_content:
                 story.extend(question_content)
                 story.append(PageBreak())
@@ -208,8 +218,35 @@ class PDFExporter:
 
         return story
 
+    def _create_question_group_analysis(self, survey_id: int, group: Dict,
+                                        include_charts: bool, index: int) -> List:
+        story = [
+            Paragraph(f"Question {index}: {group['label']}", self.styles['heading']),
+            Paragraph("Blueprint question group", self.styles['normal']),
+            Spacer(1, 0.3*cm),
+        ]
+
+        has_content = False
+        for sub_index, question in enumerate(group["questions"], start=1):
+            question_content = self._create_question_analysis(
+                survey_id,
+                question,
+                include_charts,
+                sub_index,
+                label_prefix="Subquestion",
+                force_label_prefix=True,
+            )
+            if question_content:
+                has_content = True
+                story.extend(question_content)
+                story.append(Spacer(1, 0.4*cm))
+
+        return story if has_content else []
+
     def _create_question_analysis(self, survey_id: int, question: Dict,
-                                   include_charts: bool, index: int) -> List:
+                                   include_charts: bool, index: int,
+                                   label_prefix: str = "Question",
+                                   force_label_prefix: bool = False) -> List:
         story = []
 
         question_id = get_question_id(question)
@@ -221,7 +258,12 @@ class PDFExporter:
         if len(values) == 0:
             return []
 
-        story.append(Paragraph(f"{_question_label(question, index)}: {question_text}",
+        question_label = (
+            f"{label_prefix} {index}"
+            if force_label_prefix
+            else question.get("report_label") or f"{label_prefix} {index}"
+        )
+        story.append(Paragraph(f"{question_label}: {question_text}",
                               self.styles['subheading']))
         story.append(Spacer(1, 0.2*cm))
 

--- a/backend/utils/report_factory.py
+++ b/backend/utils/report_factory.py
@@ -100,9 +100,19 @@ def _normalize_question(question: dict[str, Any], context: dict[str, Any], quest
     return normalized
 
 
-def _append_question(result: list[dict[str, Any]], question: dict[str, Any], context: dict[str, Any], question_id: str) -> None:
+def _append_question(
+    result: list[dict[str, Any]],
+    question: dict[str, Any],
+    context: dict[str, Any],
+    question_id: str,
+    group_id: str | None = None,
+    group_label: str | None = None,
+) -> None:
     normalized = _normalize_question(question, context, question_id)
     if normalized.get("type") in PASSING_QUESTION_TYPES and not _has_unresolved_tags(normalized):
+        if group_id and group_label:
+            normalized["report_group_id"] = group_id
+            normalized["report_group_label"] = group_label
         result.append(normalized)
 
 
@@ -145,6 +155,8 @@ def _expand_blueprint(question: dict[str, Any], pairs: list[dict[str, str]], gro
             subject_teachers[pair["subject"]].append(pair["teacher"])
 
         for subject, teachers in subject_teachers.items():
+            report_group_id = f"{question.get('id')}-{subject}"
+            report_group_label = subject
             for template_question in template_questions:
                 needs_teacher = _uses_tag(template_question, "teacher")
                 needs_subject = _uses_tag(template_question, "subject")
@@ -155,6 +167,8 @@ def _expand_blueprint(question: dict[str, Any], pairs: list[dict[str, str]], gro
                         template_question,
                         {"teacher": "", "subject": subject, "group": group},
                         f"{question.get('id')}-{subject}-{template_question.get('id')}",
+                        report_group_id,
+                        report_group_label,
                     )
                     continue
 
@@ -164,6 +178,8 @@ def _expand_blueprint(question: dict[str, Any], pairs: list[dict[str, str]], gro
                         template_question,
                         {"teacher": teacher, "subject": subject if needs_subject else "", "group": group},
                         f"{question.get('id')}-{subject}-{teacher}-{template_question.get('id')}",
+                        report_group_id,
+                        report_group_label,
                     )
         return result
 
@@ -172,6 +188,8 @@ def _expand_blueprint(question: dict[str, Any], pairs: list[dict[str, str]], gro
         teacher_subjects[pair["teacher"]].append(pair["subject"])
 
     for teacher, subjects in teacher_subjects.items():
+        report_group_id = f"{question.get('id')}-{teacher}"
+        report_group_label = teacher
         for template_question in template_questions:
             needs_teacher = _uses_tag(template_question, "teacher")
             needs_subject = _uses_tag(template_question, "subject")
@@ -182,6 +200,8 @@ def _expand_blueprint(question: dict[str, Any], pairs: list[dict[str, str]], gro
                     template_question,
                     {"teacher": teacher if needs_teacher else "", "subject": "", "group": group},
                     f"{question.get('id')}-{teacher}-{template_question.get('id')}",
+                    report_group_id,
+                    report_group_label,
                 )
                 continue
 
@@ -191,6 +211,8 @@ def _expand_blueprint(question: dict[str, Any], pairs: list[dict[str, str]], gro
                     template_question,
                     {"teacher": teacher if needs_teacher else "", "subject": subject, "group": group},
                     f"{question.get('id')}-{teacher}-{subject}-{template_question.get('id')}",
+                    report_group_id,
+                    report_group_label,
                 )
 
     return result

--- a/backend/utils/visualization_functions.py
+++ b/backend/utils/visualization_functions.py
@@ -49,6 +49,30 @@ def get_question_options(question: Dict[str, Any]) -> Optional[List[str]]:
     return [str(option) for option in options]
 
 
+def get_question_groups(questions: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    groups = []
+    group_indexes = {}
+
+    for question in questions:
+        group_id = question.get("report_group_id")
+        if not group_id:
+            groups.append({"type": "question", "question": question})
+            continue
+
+        if group_id not in group_indexes:
+            group_indexes[group_id] = len(groups)
+            groups.append({
+                "type": "group",
+                "id": group_id,
+                "label": question.get("report_group_label") or group_id,
+                "questions": [],
+            })
+
+        groups[group_indexes[group_id]]["questions"].append(question)
+
+    return groups
+
+
 def get_answer_question_id(answer_item: Dict[str, Any]) -> Any:
     return answer_item.get(
         "question_id",


### PR DESCRIPTION
Название задачи: Сгруппировать статистику шаблонных вопросов.

Описание изменений: развернутые шаблонные вопросы объединены в один раздел статистики для PDF и Excel, внутри группы отображаются подпункты Subquestion, для них сохраняется построение статистики и визуализаций, плоская привязка ответов не изменена.

Ссылка на issues: #182